### PR TITLE
Introduce an internal version of replaceChildren

### DIFF
--- a/src/vue-vnode-utils.ts
+++ b/src/vue-vnode-utils.ts
@@ -220,7 +220,7 @@ export const addProps = (
     checkArguments('addProps', [children, callback, options], ['array', 'function', 'object'])
   }
 
-  return replaceChildren(children, (vnode) => {
+  return replaceChildrenInternal(children, (vnode) => {
     const props = callback(vnode)
 
     if (DEV) {
@@ -246,6 +246,14 @@ export const replaceChildren = (
     checkArguments('replaceChildren', [children, callback, options], ['array', 'function', 'object'])
   }
 
+  return replaceChildrenInternal(children, callback, options)
+}
+
+const replaceChildrenInternal = (
+  children: VNodeArrayChildren,
+  callback: (vnode: VNode) => (VNode | VNodeArrayChildren | string | number | void),
+  options: IterationOptions
+): VNodeArrayChildren => {
   let nc: VNodeArrayChildren | null = null
 
   for (let index = 0; index < children.length; ++index) {
@@ -253,7 +261,7 @@ export const replaceChildren = (
 
     if (isFragment(child)) {
       const oldFragmentChildren = getFragmentChildren(child)
-      const newFragmentChildren = replaceChildren(oldFragmentChildren, callback, options)
+      const newFragmentChildren = replaceChildrenInternal(oldFragmentChildren, callback, options)
 
       let newChild: VNodeChild = child
 
@@ -313,7 +321,7 @@ export const betweenChildren = (
 
   let previousVNode: VNode | null = null
 
-  return replaceChildren(children, vnode => {
+  return replaceChildrenInternal(children, vnode => {
     let insertedNodes: VNode | VNodeArrayChildren | string | number | void = undefined
 
     if (previousVNode) {


### PR DESCRIPTION
`replaceChildren()` is used by `addProps()` and `betweenChildren()` internally. This PR introduces `replaceChildrenInternal()` that all 3 can use instead.

`replaceChildrenInternal()` doesn't have the dev warnings for the arguments. This avoids duplicate warnings when `addProps()` or `betweenChildren()` call it, or when it calls itself recursively. This does potentially remove an argument check on the children for recursive calls, but that really isn't an edge case those checks were intended to catch. The warnings in that unlikely scenario would have been confusing anyway.

`replaceChildrenInternal()` also doesn't specify a default for the `options` argument. This potentially allows `SKIP_COMMENTS` to be tree-shaken if `replaceChildren()` isn't used directly.