### PR TITLE
Fix the types for isComment and isText

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -204,7 +204,7 @@ If the passed value doesn't appear to be convertible to a VNode, the returned va
 ### Type
 
 ```ts
-function isComment(vnode: any): vnode is (null | undefined | boolean | (VNode & { type: Comment }))
+function isComment(vnode: any): vnode is (null | undefined | boolean | (VNode & { type: typeof Comment }))
 ```
 
 ### Description
@@ -346,7 +346,7 @@ Returns `true` if the passed value is a static VNode. Static VNodes are a specia
 ### Type
 
 ```ts
-function isText(vnode: any): vnode is (string | number | (VNode & { type: Text }))
+function isText(vnode: any): vnode is (string | number | (VNode & { type: typeof Text }))
 ```
 
 ### Description

--- a/src/vue-vnode-utils.ts
+++ b/src/vue-vnode-utils.ts
@@ -1,15 +1,15 @@
 import {
   cloneVNode,
-  Comment,
+  Comment as CommentVNode,
   type Component,
   type ComponentOptions,
   createCommentVNode,
   createTextVNode,
-  Fragment,
+  Fragment as FragmentVNode,
   type FunctionalComponent,
   isVNode,
-  Static,
-  Text,
+  Static as StaticVNode,
+  Text as TextVNode,
   type VNode,
   type VNodeArrayChildren,
   type VNodeChild
@@ -18,7 +18,7 @@ import {
 // @ts-ignore
 const DEV = process.env.NODE_ENV !== 'production'
 
-export const isComment = (vnode: unknown): vnode is (null | undefined | boolean | (VNode & { type: Comment })) => {
+export const isComment = (vnode: unknown): vnode is (null | undefined | boolean | (VNode & { type: typeof CommentVNode })) => {
   return getType(vnode) === 'comment'
 }
 
@@ -30,7 +30,7 @@ export const isElement = (vnode: unknown): vnode is (VNode & { type: string }) =
   return getType(vnode) === 'element'
 }
 
-export const isFragment = (vnode: unknown): vnode is ((VNode & { type: typeof Fragment }) | VNodeArrayChildren) => {
+export const isFragment = (vnode: unknown): vnode is ((VNode & { type: typeof FragmentVNode }) | VNodeArrayChildren) => {
   return getType(vnode) === 'fragment'
 }
 
@@ -42,11 +42,11 @@ export const isStatefulComponent = (vnode: unknown): vnode is (VNode & { type: C
   return isComponent(vnode) && typeof vnode.type === 'object'
 }
 
-export const isStatic = (vnode: unknown): vnode is (VNode & { type: typeof Static }) => {
+export const isStatic = (vnode: unknown): vnode is (VNode & { type: typeof StaticVNode }) => {
   return getType(vnode) === 'static'
 }
 
-export const isText = (vnode: unknown): vnode is (string | number | (VNode & { type: Text })) => {
+export const isText = (vnode: unknown): vnode is (string | number | (VNode & { type: typeof TextVNode })) => {
   return getType(vnode) === 'text'
 }
 
@@ -59,7 +59,7 @@ export const getText = (vnode: VNode | string | number): string | undefined => {
     return String(vnode)
   }
 
-  if (isVNode(vnode) && vnode.type === Text) {
+  if (isVNode(vnode) && vnode.type === TextVNode) {
     return String(vnode.children)
   }
 
@@ -119,13 +119,13 @@ export const getType = (vnode: unknown) => {
     const typeofType = typeof type
 
     if (typeofType === 'symbol') {
-      if (type === Fragment) {
+      if (type === FragmentVNode) {
         return 'fragment'
-      } else if (type === Text) {
+      } else if (type === TextVNode) {
         return 'text'
-      } else if (type === Comment) {
+      } else if (type === CommentVNode) {
         return 'comment'
-      } else if (type === Static) {
+      } else if (type === StaticVNode) {
         return 'static'
       }
     } else if (typeofType === 'string') {


### PR DESCRIPTION
The types for `isComment` and `isText` were using `Comment` and `Text` incorrectly.

Both `Comment` and `Text` were being imported from `vue`, but they weren't actually being used for the types of those two functions. Those values are both symbols, not types, so they were ignored in the type annotation. Instead, the global `Comment` and `Text` types, used for DOM nodes, were being used.

The simplest fix was to use `typeof Comment` and `typeof Text`, but to avoid future clashes I've renamed all the imported symbols to have less problematic names.

The docs have been updated accordingly, though they still use the original names for the symbols.